### PR TITLE
Update base image and install ext-sockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.13-fpm
+FROM php:7.1.27-fpm-stretch
 
 MAINTAINER Abed Halawi <abed.halawi@vinelab.com>
 
@@ -9,6 +9,7 @@ RUN apt-get update
 RUN apt-get install -y autoconf pkg-config libssl-dev
 RUN pecl install mongodb-1.2.2
 RUN docker-php-ext-install bcmath
+RUN docker-php-ext-install sockets
 RUN echo "extension=mongodb.so" >> /usr/local/etc/php/conf.d/mongodb.ini
 
 RUN apt-get update


### PR DESCRIPTION
Newer versions of [Bowler](https://github.com/Vinelab/bowler/releases/tag/v0.4.4) depend on `php-amqp-2.8.1` which requries ext-sockets being installed on the system. 

This PR updates composer image in order to install ext-sockets. Consequently, PHP base image is also updated to `php:7.1.27-fpm-stretch` because I am unable to fetch from Jessie repositories when building the old image.

You can download [sample built image from Docker Hub](https://cloud.docker.com/u/adiachenko/repository/docker/adiachenko/docker-php-nginx) in order to test stuff.