### PR TITLE
Make recent image changes consistent with other branches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
 FROM php:7.1.27-fpm-stretch
 
-MAINTAINER Abed Halawi <abed.halawi@vinelab.com>
+LABEL maintainer="Abed Halawi <abed.halawi@vinelab.com>"
 
 ENV php_conf /usr/local/etc/php/php.ini
 ENV fpm_conf /usr/local/etc/php/php-fpm.conf
 
-RUN apt-get update
-RUN apt-get install -y autoconf pkg-config libssl-dev
-RUN pecl install mongodb-1.2.2
+RUN apt-get update \
+    && apt-get install -y autoconf pkg-config libssl-dev
+
 RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install sockets
-RUN echo "extension=mongodb.so" >> /usr/local/etc/php/conf.d/mongodb.ini
 
-RUN apt-get update
-RUN apt-get install -y nginx supervisor
+RUN pecl install mongodb-1.2.2  \
+    && docker-php-ext-enable mongodb
+
+RUN apt-get update \
+    && apt-get install -y nginx supervisor cron
 
 RUN mkdir /code
 
@@ -30,10 +32,11 @@ VOLUME /code
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 # Install composer
-RUN apt-get install -y git zip
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
-RUN chmod +x /usr/local/bin/composer
+RUN apt-get update \
+    && apt-get install -y git zip \
+    && curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer
 
 WORKDIR /code
 


### PR DESCRIPTION
Test image:

```sh
docker pull adiachenko/docker-php-nginx:composer
```

**NOTE:**
I noticed that composer image doesn't install php zip extension unlike the other 2 (master and mole). Is this intentional?